### PR TITLE
feat: add user-friendly admin CRUD with dropdowns

### DIFF
--- a/src/app/admin/page.jsx
+++ b/src/app/admin/page.jsx
@@ -202,7 +202,7 @@ function ShowsSection({ supabase }) {
             <img
               src={form.poster_URL}
               alt="poster preview"
-              className="mt-2 h-24 object-cover"
+              className="mt-2 h-48 object-cover"
             />
           )}
         </div>
@@ -217,7 +217,7 @@ function ShowsSection({ supabase }) {
             <img
               src={form.image_URL}
               alt="image preview"
-              className="mt-2 h-24 object-cover"
+              className="mt-2 h-48 object-cover"
             />
           )}
         </div>
@@ -436,7 +436,7 @@ function EmployeesSection({ supabase }) {
             <img
               src={form.profile_picture_URL}
               alt="profile preview"
-              className="mt-2 h-24 object-cover"
+              className="mt-2 h-48 object-cover"
             />
           )}
         </div>

--- a/src/app/admin/page.jsx
+++ b/src/app/admin/page.jsx
@@ -248,8 +248,6 @@ function ShowsSection({ supabase }) {
       </form>
       <table className="w-full text-sm border border-gray-200">
         <thead className="bg-gray-100">
-      <table className="w-full text-sm border border-gray-200">
-        <thead className="bg-gray-100">
           <tr>
             <th className="p-2 text-left border-b">ID</th>
             <th className="p-2 text-left border-b">Title</th>
@@ -459,8 +457,6 @@ function EmployeesSection({ supabase }) {
       </form>
       <table className="w-full text-sm border border-gray-200">
         <thead className="bg-gray-100">
-      <table className="w-full text-sm border border-gray-200">
-        <thead className="bg-gray-100">
           <tr>
             <th className="p-2 text-left border-b">ID</th>
             <th className="p-2 text-left border-b">Name</th>
@@ -583,8 +579,6 @@ function PerformancesSection({ supabase }) {
           {editingId ? 'Update' : 'Add'}
         </button>
       </form>
-      <table className="w-full text-sm border border-gray-200">
-        <thead className="bg-gray-100">
       <table className="w-full text-sm border border-gray-200">
         <thead className="bg-gray-100">
           <tr>


### PR DESCRIPTION
## Summary
- redesign admin dashboard with blue sidebar and tabbed navigation
- add editable forms for shows, employees, performances and cast with dropdowns for related data

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Sofia Sans` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c540f644c4832bb3e6c20fc09b6459