### PR TITLE
Revamp admin dashboard design and validation

### DIFF
--- a/src/app/admin/page.jsx
+++ b/src/app/admin/page.jsx
@@ -10,13 +10,26 @@ const tabs = [
   { key: 'cast', label: 'Cast' },
 ]
 
+const inputClass =
+  'border border-theater-light rounded p-2 bg-theater-light text-white'
+const buttonClass =
+  'bg-theater-accent text-theater-dark px-4 py-2 rounded self-end'
+
+function generateSlug(text) {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+}
+
 export default function AdminPage() {
   const supabase = createClient()
   const [activeTab, setActiveTab] = useState('shows')
 
   return (
-    <div className="flex h-screen bg-gray-100">
-      <aside className="w-64 bg-blue-900 text-white p-4">
+    <div className="flex h-screen bg-theater-light text-white">
+      <aside className="w-64 bg-theater-dark text-white p-4">
         <h1 className="text-2xl font-bold mb-6">Admin</h1>
         <nav className="flex flex-col gap-2">
           {tabs.map((tab) => (
@@ -25,8 +38,8 @@ export default function AdminPage() {
               onClick={() => setActiveTab(tab.key)}
               className={`text-left px-3 py-2 rounded transition-colors ${
                 activeTab === tab.key
-                  ? 'bg-blue-700'
-                  : 'hover:bg-blue-700/50'
+                  ? 'bg-theater-accent text-theater-dark'
+                  : 'hover:bg-theater-light'
               }`}
             >
               {tab.label}
@@ -82,6 +95,10 @@ function ShowsSection({ supabase }) {
 
   async function handleSubmit(e) {
     e.preventDefault()
+    if (!form.title.trim() || !form.slug.trim() || !form.category.trim()) {
+      alert('Title, category and slug are required.')
+      return
+    }
     if (editingId) {
       await supabase.from('shows').update(form).eq('id', editingId)
     } else {
@@ -127,7 +144,7 @@ function ShowsSection({ supabase }) {
   }
 
   return (
-    <section className="bg-white p-6 rounded shadow">
+    <section className="bg-theater-dark p-6 rounded shadow text-white">
       <h2 className="text-xl font-semibold mb-4">Shows</h2>
       <div className="flex justify-between mb-4">
         <input
@@ -137,13 +154,13 @@ function ShowsSection({ supabase }) {
             setSearch(e.target.value)
             setPage(0)
           }}
-          className="border rounded p-2"
+          className={inputClass}
         />
         <div className="space-x-2">
           <button
             onClick={() => setPage((p) => Math.max(p - 1, 0))}
             disabled={page === 0}
-            className="px-2 py-1 border rounded disabled:opacity-50"
+            className="px-2 py-1 border border-theater-light rounded disabled:opacity-50 bg-theater-light"
           >
             Prev
           </button>
@@ -152,7 +169,7 @@ function ShowsSection({ supabase }) {
               setPage((p) => (p + 1) * pageSize < count ? p + 1 : p)
             }
             disabled={(page + 1) * pageSize >= count}
-            className="px-2 py-1 border rounded disabled:opacity-50"
+            className="px-2 py-1 border border-theater-light rounded disabled:opacity-50 bg-theater-light"
           >
             Next
           </button>
@@ -163,24 +180,25 @@ function ShowsSection({ supabase }) {
           <label className="text-sm font-medium">Title</label>
           <input
             value={form.title}
-            onChange={(e) => setForm({ ...form, title: e.target.value })}
-            className="border rounded p-2"
+            onChange={(e) => {
+              const title = e.target.value
+              setForm({ ...form, title, slug: generateSlug(title) })
+            }}
+            required
+            className={inputClass}
           />
         </div>
         <div className="flex flex-col">
           <label className="text-sm font-medium">Slug</label>
-          <input
-            value={form.slug}
-            onChange={(e) => setForm({ ...form, slug: e.target.value })}
-            className="border rounded p-2"
-          />
+          <input value={form.slug} readOnly className={`${inputClass} opacity-50`} />
         </div>
         <div className="flex flex-col">
           <label className="text-sm font-medium">Category</label>
           <input
             value={form.category}
             onChange={(e) => setForm({ ...form, category: e.target.value })}
-            className="border rounded p-2"
+            required
+            className={inputClass}
           />
         </div>
         <div className="flex flex-col">
@@ -188,7 +206,8 @@ function ShowsSection({ supabase }) {
           <input
             value={form.author}
             onChange={(e) => setForm({ ...form, author: e.target.value })}
-            className="border rounded p-2"
+            required
+            className={inputClass}
           />
         </div>
         <div className="flex flex-col">
@@ -196,7 +215,7 @@ function ShowsSection({ supabase }) {
           <input
             type="file"
             onChange={(e) => handleFileChange(e, 'poster_URL', 'Posters')}
-            className="border rounded p-2"
+            className={inputClass}
           />
           {form.poster_URL && (
             <img
@@ -211,7 +230,7 @@ function ShowsSection({ supabase }) {
           <input
             type="file"
             onChange={(e) => handleFileChange(e, 'image_URL', 'BigPicturePlays')}
-            className="border rounded p-2"
+            className={inputClass}
           />
           {form.image_URL && (
             <img
@@ -226,7 +245,8 @@ function ShowsSection({ supabase }) {
           <textarea
             value={form.information}
             onChange={(e) => setForm({ ...form, information: e.target.value })}
-            className="border rounded p-2"
+            className={`${inputClass} h-32`}
+            required
           />
         </div>
         <div className="flex flex-col sm:col-span-2">
@@ -236,48 +256,45 @@ function ShowsSection({ supabase }) {
             onChange={(e) =>
               setForm({ ...form, picture_personalURL: e.target.value })
             }
-            className="border rounded p-2"
+            className={inputClass}
           />
         </div>
-        <button
-          type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded self-end"
-        >
+        <button type="submit" className={buttonClass}>
           {editingId ? 'Update' : 'Add'}
         </button>
       </form>
-      <table className="w-full text-sm border border-gray-200">
-        <thead className="bg-gray-100">
+      <table className="w-full text-sm border border-theater-light">
+        <thead className="bg-theater-light">
           <tr>
-            <th className="p-2 text-left border-b">ID</th>
-            <th className="p-2 text-left border-b">Title</th>
-            <th className="p-2 text-left border-b">Category</th>
-            <th className="p-2 text-left border-b">Cast</th>
-            <th className="p-2 text-left border-b">Actions</th>
+            <th className="p-2 text-left border-b border-theater-light">ID</th>
+            <th className="p-2 text-left border-b border-theater-light">Title</th>
+            <th className="p-2 text-left border-b border-theater-light">Category</th>
+            <th className="p-2 text-left border-b border-theater-light">Cast</th>
+            <th className="p-2 text-left border-b border-theater-light">Actions</th>
           </tr>
         </thead>
         <tbody>
           {items.map((item) => (
-            <tr key={item.id} className="odd:bg-gray-50">
-              <td className="p-2 border-b">{item.id}</td>
-              <td className="p-2 border-b">{item.title}</td>
-              <td className="p-2 border-b">{item.category}</td>
-              <td className="p-2 border-b">
+            <tr key={item.id} className="odd:bg-theater-light/20">
+              <td className="p-2 border-b border-theater-light">{item.id}</td>
+              <td className="p-2 border-b border-theater-light">{item.title}</td>
+              <td className="p-2 border-b border-theater-light">{item.category}</td>
+              <td className="p-2 border-b border-theater-light">
                 {item.cast_members
                   ?.map((cm) => cm.employees?.name)
                   .filter(Boolean)
                   .join(', ')}
               </td>
-              <td className="p-2 border-b space-x-2">
+              <td className="p-2 border-b border-theater-light space-x-2">
                 <button
                   onClick={() => handleEdit(item)}
-                  className="text-blue-600 hover:underline"
+                  className="text-theater-accent hover:underline"
                 >
                   Edit
                 </button>
                 <button
                   onClick={() => handleDelete(item.id)}
-                  className="text-red-600 hover:underline"
+                  className="text-red-500 hover:underline"
                 >
                   Delete
                 </button>
@@ -325,6 +342,10 @@ function EmployeesSection({ supabase }) {
 
   async function handleSubmit(e) {
     e.preventDefault()
+    if (!form.name.trim() || !form.role.trim()) {
+      alert('Name and role are required.')
+      return
+    }
     const payload = { ...form, dateOfBirth: form.dateOfBirth || null }
     if (editingId) {
       await supabase.from('employees').update(payload).eq('id', editingId)
@@ -368,7 +389,7 @@ function EmployeesSection({ supabase }) {
   }
 
   return (
-    <section className="bg-white p-6 rounded shadow">
+    <section className="bg-theater-dark p-6 rounded shadow text-white">
       <h2 className="text-xl font-semibold mb-4">Employees</h2>
       <div className="flex justify-between mb-4">
         <input
@@ -378,13 +399,13 @@ function EmployeesSection({ supabase }) {
             setSearch(e.target.value)
             setPage(0)
           }}
-          className="border rounded p-2"
+          className={inputClass}
         />
         <div className="space-x-2">
           <button
             onClick={() => setPage((p) => Math.max(p - 1, 0))}
             disabled={page === 0}
-            className="px-2 py-1 border rounded disabled:opacity-50"
+            className="px-2 py-1 border border-theater-light rounded disabled:opacity-50 bg-theater-light"
           >
             Prev
           </button>
@@ -393,7 +414,7 @@ function EmployeesSection({ supabase }) {
               setPage((p) => (p + 1) * pageSize < count ? p + 1 : p)
             }
             disabled={(page + 1) * pageSize >= count}
-            className="px-2 py-1 border rounded disabled:opacity-50"
+            className="px-2 py-1 border border-theater-light rounded disabled:opacity-50 bg-theater-light"
           >
             Next
           </button>
@@ -405,7 +426,8 @@ function EmployeesSection({ supabase }) {
           <input
             value={form.name}
             onChange={(e) => setForm({ ...form, name: e.target.value })}
-            className="border rounded p-2"
+            required
+            className={inputClass}
           />
         </div>
         <div className="flex flex-col">
@@ -413,7 +435,8 @@ function EmployeesSection({ supabase }) {
           <input
             value={form.role}
             onChange={(e) => setForm({ ...form, role: e.target.value })}
-            className="border rounded p-2"
+            required
+            className={inputClass}
           />
         </div>
         <div className="flex flex-col">
@@ -422,7 +445,7 @@ function EmployeesSection({ supabase }) {
             type="date"
             value={form.dateOfBirth}
             onChange={(e) => setForm({ ...form, dateOfBirth: e.target.value })}
-            className="border rounded p-2"
+            className={inputClass}
           />
         </div>
         <div className="flex flex-col">
@@ -430,7 +453,7 @@ function EmployeesSection({ supabase }) {
           <input
             type="file"
             onChange={handleFileChange}
-            className="border rounded p-2"
+            className={inputClass}
           />
           {form.profile_picture_URL && (
             <img
@@ -445,41 +468,38 @@ function EmployeesSection({ supabase }) {
           <textarea
             value={form.bio}
             onChange={(e) => setForm({ ...form, bio: e.target.value })}
-            className="border rounded p-2"
+            className={`${inputClass} h-32`}
           />
         </div>
-        <button
-          type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded self-end"
-        >
+        <button type="submit" className={buttonClass}>
           {editingId ? 'Update' : 'Add'}
         </button>
       </form>
-      <table className="w-full text-sm border border-gray-200">
-        <thead className="bg-gray-100">
+      <table className="w-full text-sm border border-theater-light">
+        <thead className="bg-theater-light">
           <tr>
-            <th className="p-2 text-left border-b">ID</th>
-            <th className="p-2 text-left border-b">Name</th>
-            <th className="p-2 text-left border-b">Role</th>
-            <th className="p-2 text-left border-b">Actions</th>
+            <th className="p-2 text-left border-b border-theater-light">ID</th>
+            <th className="p-2 text-left border-b border-theater-light">Name</th>
+            <th className="p-2 text-left border-b border-theater-light">Role</th>
+            <th className="p-2 text-left border-b border-theater-light">Actions</th>
           </tr>
         </thead>
         <tbody>
           {items.map((item) => (
-            <tr key={item.id} className="odd:bg-gray-50">
-              <td className="p-2 border-b">{item.id}</td>
-              <td className="p-2 border-b">{item.name}</td>
-              <td className="p-2 border-b">{item.role}</td>
-              <td className="p-2 border-b space-x-2">
+            <tr key={item.id} className="odd:bg-theater-light/20">
+              <td className="p-2 border-b border-theater-light">{item.id}</td>
+              <td className="p-2 border-b border-theater-light">{item.name}</td>
+              <td className="p-2 border-b border-theater-light">{item.role}</td>
+              <td className="p-2 border-b border-theater-light space-x-2">
                 <button
                   onClick={() => handleEdit(item)}
-                  className="text-blue-600 hover:underline"
+                  className="text-theater-accent hover:underline"
                 >
                   Edit
                 </button>
                 <button
                   onClick={() => handleDelete(item.id)}
-                  className="text-red-600 hover:underline"
+                  className="text-red-500 hover:underline"
                 >
                   Delete
                 </button>
@@ -519,6 +539,10 @@ function PerformancesSection({ supabase }) {
 
   async function handleSubmit(e) {
     e.preventDefault()
+    if (!form.idShow || !form.time) {
+      alert('Show and time are required.')
+      return
+    }
     if (editingId) {
       await supabase
         .from('performances')
@@ -545,7 +569,7 @@ function PerformancesSection({ supabase }) {
   }
 
   return (
-    <section className="bg-white p-6 rounded shadow">
+    <section className="bg-theater-dark p-6 rounded shadow text-white">
       <h2 className="text-xl font-semibold mb-4">Performances</h2>
       <form onSubmit={handleSubmit} className="grid gap-4 sm:grid-cols-3 mb-6">
         <div className="flex flex-col">
@@ -553,7 +577,8 @@ function PerformancesSection({ supabase }) {
           <select
             value={form.idShow}
             onChange={(e) => setForm({ ...form, idShow: e.target.value })}
-            className="border rounded p-2"
+            required
+            className={inputClass}
           >
             <option value="">Select show</option>
             {shows.map((show) => (
@@ -569,41 +594,39 @@ function PerformancesSection({ supabase }) {
             type="datetime-local"
             value={form.time}
             onChange={(e) => setForm({ ...form, time: e.target.value })}
-            className="border rounded p-2"
+            required
+            className={inputClass}
           />
         </div>
-        <button
-          type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded self-end"
-        >
+        <button type="submit" className={buttonClass}>
           {editingId ? 'Update' : 'Add'}
         </button>
       </form>
-      <table className="w-full text-sm border border-gray-200">
-        <thead className="bg-gray-100">
+      <table className="w-full text-sm border border-theater-light">
+        <thead className="bg-theater-light">
           <tr>
-            <th className="p-2 text-left border-b">ID</th>
-            <th className="p-2 text-left border-b">Show</th>
-            <th className="p-2 text-left border-b">Time</th>
-            <th className="p-2 text-left border-b">Actions</th>
+            <th className="p-2 text-left border-b border-theater-light">ID</th>
+            <th className="p-2 text-left border-b border-theater-light">Show</th>
+            <th className="p-2 text-left border-b border-theater-light">Time</th>
+            <th className="p-2 text-left border-b border-theater-light">Actions</th>
           </tr>
         </thead>
         <tbody>
           {items.map((item) => (
-            <tr key={item.id} className="odd:bg-gray-50">
-              <td className="p-2 border-b">{item.id}</td>
-              <td className="p-2 border-b">{item.shows?.title}</td>
-              <td className="p-2 border-b">{item.time}</td>
-              <td className="p-2 border-b space-x-2">
+            <tr key={item.id} className="odd:bg-theater-light/20">
+              <td className="p-2 border-b border-theater-light">{item.id}</td>
+              <td className="p-2 border-b border-theater-light">{item.shows?.title}</td>
+              <td className="p-2 border-b border-theater-light">{item.time}</td>
+              <td className="p-2 border-b border-theater-light space-x-2">
                 <button
                   onClick={() => handleEdit(item)}
-                  className="text-blue-600 hover:underline"
+                  className="text-theater-accent hover:underline"
                 >
                   Edit
                 </button>
                 <button
                   onClick={() => handleDelete(item.id)}
-                  className="text-red-600 hover:underline"
+                  className="text-red-500 hover:underline"
                 >
                   Delete
                 </button>
@@ -650,6 +673,10 @@ function CastSection({ supabase }) {
 
   async function handleSubmit(e) {
     e.preventDefault()
+    if (!form.idShow || !form.employeeId) {
+      alert('Show and employee are required.')
+      return
+    }
     if (editingId) {
       await supabase
         .from('cast_members')
@@ -676,7 +703,7 @@ function CastSection({ supabase }) {
   }
 
   return (
-    <section className="bg-white p-6 rounded shadow">
+    <section className="bg-theater-dark p-6 rounded shadow text-white">
       <h2 className="text-xl font-semibold mb-4">Cast</h2>
       <form onSubmit={handleSubmit} className="grid gap-4 sm:grid-cols-3 mb-6">
         <div className="flex flex-col">
@@ -684,7 +711,8 @@ function CastSection({ supabase }) {
           <select
             value={form.idShow}
             onChange={(e) => setForm({ ...form, idShow: e.target.value })}
-            className="border rounded p-2"
+            required
+            className={inputClass}
           >
             <option value="">Select show</option>
             {shows.map((show) => (
@@ -699,7 +727,8 @@ function CastSection({ supabase }) {
           <select
             value={form.employeeId}
             onChange={(e) => setForm({ ...form, employeeId: e.target.value })}
-            className="border rounded p-2"
+            required
+            className={inputClass}
           >
             <option value="">Select employee</option>
             {employees.map((emp) => (
@@ -709,38 +738,35 @@ function CastSection({ supabase }) {
             ))}
           </select>
         </div>
-        <button
-          type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded self-end"
-        >
+        <button type="submit" className={buttonClass}>
           {editingId ? 'Update' : 'Add'}
         </button>
       </form>
-      <table className="w-full text-sm border border-gray-200">
-        <thead className="bg-gray-100">
+      <table className="w-full text-sm border border-theater-light">
+        <thead className="bg-theater-light">
           <tr>
-            <th className="p-2 text-left border-b">ID</th>
-            <th className="p-2 text-left border-b">Show</th>
-            <th className="p-2 text-left border-b">Employee</th>
-            <th className="p-2 text-left border-b">Actions</th>
+            <th className="p-2 text-left border-b border-theater-light">ID</th>
+            <th className="p-2 text-left border-b border-theater-light">Show</th>
+            <th className="p-2 text-left border-b border-theater-light">Employee</th>
+            <th className="p-2 text-left border-b border-theater-light">Actions</th>
           </tr>
         </thead>
         <tbody>
           {items.map((item) => (
-            <tr key={item.id} className="odd:bg-gray-50">
-              <td className="p-2 border-b">{item.id}</td>
-              <td className="p-2 border-b">{item.shows?.title}</td>
-              <td className="p-2 border-b">{item.employees?.name}</td>
-              <td className="p-2 border-b space-x-2">
+            <tr key={item.id} className="odd:bg-theater-light/20">
+              <td className="p-2 border-b border-theater-light">{item.id}</td>
+              <td className="p-2 border-b border-theater-light">{item.shows?.title}</td>
+              <td className="p-2 border-b border-theater-light">{item.employees?.name}</td>
+              <td className="p-2 border-b border-theater-light space-x-2">
                 <button
                   onClick={() => handleEdit(item)}
-                  className="text-blue-600 hover:underline"
+                  className="text-theater-accent hover:underline"
                 >
                   Edit
                 </button>
                 <button
                   onClick={() => handleDelete(item.id)}
-                  className="text-red-600 hover:underline"
+                  className="text-red-500 hover:underline"
                 >
                   Delete
                 </button>


### PR DESCRIPTION
## Summary
- restyle admin dashboard with theater color theme and shared input styles
- auto-generate show slugs from titles and validate required fields across all sections
- enlarge employee bio editor for easier content entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56d322f54832bb0ef5fdbb899e75c