### PR TITLE
fix: access is_admin from app metadata

### DIFF
--- a/supabase/rls-policies.sql
+++ b/supabase/rls-policies.sql
@@ -2,23 +2,23 @@
 alter table public.shows enable row level security;
 create policy "Shows admin mutations" on public.shows
   for all
-  using (auth.jwt() ->> 'is_admin' = 'true')
-  with check (auth.jwt() ->> 'is_admin' = 'true');
+  using (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true')
+  with check (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true');
 
 alter table public.employees enable row level security;
 create policy "Employees admin mutations" on public.employees
   for all
-  using (auth.jwt() ->> 'is_admin' = 'true')
-  with check (auth.jwt() ->> 'is_admin' = 'true');
+  using (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true')
+  with check (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true');
 
 alter table public.performances enable row level security;
 create policy "Performances admin mutations" on public.performances
   for all
-  using (auth.jwt() ->> 'is_admin' = 'true')
-  with check (auth.jwt() ->> 'is_admin' = 'true');
+  using (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true')
+  with check (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true');
 
 alter table public.cast_members enable row level security;
 create policy "Cast members admin mutations" on public.cast_members
   for all
-  using (auth.jwt() ->> 'is_admin' = 'true')
-  with check (auth.jwt() ->> 'is_admin' = 'true');
+  using (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true')
+  with check (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true');


### PR DESCRIPTION
## Summary
- access `is_admin` from JWT `app_metadata` in all RLS policies

## Testing
- `npm run lint` (passes)
- `npm install -g supabase` (failed: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68c58433d388832b9cfc3e5a0e5a0901