### PR TITLE
Require login for admin dashboard

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -25,7 +25,7 @@ export async function middleware(req) {
     data: { session },
   } = await supabase.auth.getSession();
 
-  if (!session || !session.user?.app_metadata?.is_admin) {
+  if (!session) {
     const url = new URL('/login', req.url);
     return NextResponse.redirect(url);
   }

--- a/src/app/admin/layout.jsx
+++ b/src/app/admin/layout.jsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '../../../lib/supabase/server'
+
+export default async function AdminLayout({ children }) {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) {
+    redirect('/login')
+  }
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- remove admin metadata requirement from auth middleware so normal sessions can access the dashboard
- add server-side layout for /admin that redirects unauthenticated visitors to /login

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5863f5248832bb631513aa55ded22