### PR TITLE
feat: allow service role for employee mutations

### DIFF
--- a/supabase/rls-policies.sql
+++ b/supabase/rls-policies.sql
@@ -8,8 +8,14 @@ create policy "Shows admin mutations" on public.shows
 alter table public.employees enable row level security;
 create policy "Employees admin mutations" on public.employees
   for all
-  using (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true')
-  with check (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true');
+  using (
+    auth.role() = 'service_role'
+    or auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true'
+  )
+  with check (
+    auth.role() = 'service_role'
+    or auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true'
+  );
 
 alter table public.performances enable row level security;
 create policy "Performances admin mutations" on public.performances


### PR DESCRIPTION
## Summary
- allow service role tokens to bypass employees RLS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `psql -f supabase/rls-policies.sql` *(command not found)*
- `supabase db push` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b7118c64832b967eeb1937bc33e9