### PR TITLE
feat: manage admin permissions

### DIFF
--- a/lib/supabase/admin.js
+++ b/lib/supabase/admin.js
@@ -1,0 +1,11 @@
+import { createClient } from '@supabase/supabase-js'
+
+export function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    {
+      auth: { persistSession: false },
+    }
+  )
+}

--- a/src/app/admin/admins-section.jsx
+++ b/src/app/admin/admins-section.jsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useState } from 'react'
+import StatusMessage from '../../components/ui/status-message'
+
+const inputClass =
+  'border border-theater-light rounded p-2 bg-theater-light text-white'
+const buttonBaseClass = 'text-theater-dark px-4 py-2 rounded self-end'
+
+export default function AdminsSection() {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState(null)
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setStatus(null)
+    const res = await fetch('/api/admin/make-admin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      setStatus({ type: 'error', message: data.error || 'Failed to update' })
+    } else {
+      setStatus({ type: 'success', message: 'User granted admin rights.' })
+      setEmail('')
+    }
+  }
+
+  return (
+    <section className="bg-theater-dark p-6 rounded shadow text-white">
+      <h2 className="text-xl font-semibold mb-4">Admin Permissions</h2>
+      <form onSubmit={handleSubmit} className="flex gap-4 items-end mb-4">
+        <div className="flex flex-col flex-1">
+          <label className="text-sm font-medium">User Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className={inputClass}
+          />
+        </div>
+        <button type="submit" className={`${buttonBaseClass} bg-green-500`}>
+          Make Admin
+        </button>
+      </form>
+      <StatusMessage status={status} onClear={() => setStatus(null)} />
+    </section>
+  )
+}

--- a/src/app/admin/page.jsx
+++ b/src/app/admin/page.jsx
@@ -3,12 +3,14 @@
 import { useState, useEffect } from 'react'
 import { createClient } from '../../../lib/supabase/client'
 import StatusMessage from '../../components/ui/status-message'
+import AdminsSection from './admins-section'
 
 const tabs = [
   { key: 'shows', label: 'Shows' },
   { key: 'employees', label: 'Employees' },
   { key: 'performances', label: 'Performances' },
   { key: 'cast', label: 'Cast' },
+  { key: 'admins', label: 'Admins' },
 ]
 
 const inputClass =
@@ -63,6 +65,7 @@ export default function AdminPage() {
         {activeTab === 'employees' && <EmployeesSection supabase={supabase} />}
         {activeTab === 'performances' && <PerformancesSection supabase={supabase} />}
         {activeTab === 'cast' && <CastSection supabase={supabase} />}
+        {activeTab === 'admins' && <AdminsSection />}
       </main>
     </div>
   )

--- a/src/app/api/admin/make-admin/route.js
+++ b/src/app/api/admin/make-admin/route.js
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import { createAdminClient } from '../../../../lib/supabase/admin'
+
+export async function POST(request) {
+  const { email, is_admin = true } = await request.json()
+  if (!email) {
+    return NextResponse.json({ error: 'Email is required' }, { status: 400 })
+  }
+
+  const supabase = createAdminClient()
+
+  const { data: list, error: listError } = await supabase.auth.admin.listUsers()
+  if (listError) {
+    return NextResponse.json({ error: listError.message }, { status: 400 })
+  }
+  const user = list.users.find((u) => u.email === email)
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+  const { error } = await supabase.auth.admin.updateUserById(user.id, {
+    app_metadata: { is_admin },
+  })
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 })
+  }
+  return NextResponse.json({ success: true })
+}

--- a/supabase/rls-policies.sql
+++ b/supabase/rls-policies.sql
@@ -1,3 +1,12 @@
+-- Ensure initial admin user exists
+update auth.users
+set raw_app_meta_data = jsonb_set(
+  coalesce(raw_app_meta_data, '{}'::jsonb),
+  '{is_admin}',
+  'true'::jsonb
+)
+where email = 'kalopizata28@gmail.com';
+
 -- Enable RLS and restrict mutations to admins only
 alter table public.shows enable row level security;
 create policy "Shows admin mutations" on public.shows
@@ -8,8 +17,14 @@ create policy "Shows admin mutations" on public.shows
 alter table public.employees enable row level security;
 create policy "Employees admin mutations" on public.employees
   for all
-  using (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true')
-  with check (auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true');
+  using (
+    auth.role() = 'service_role'
+    or auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true'
+  )
+  with check (
+    auth.role() = 'service_role'
+    or auth.jwt() -> 'app_metadata' ->> 'is_admin' = 'true'
+  );
 
 alter table public.performances enable row level security;
 create policy "Performances admin mutations" on public.performances


### PR DESCRIPTION
## Summary
- seed initial admin user
- allow promoting users to admin via admin panel

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `psql -f supabase/rls-policies.sql` *(command not found)*
- `supabase db push` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b7118c64832b967eeb1937bc33e9