### PR TITLE
Transform performance data for program guide

### DIFF
--- a/src/app/program/page.jsx
+++ b/src/app/program/page.jsx
@@ -4,33 +4,45 @@ import { createClient } from "../../../lib/supabase/server";
 
 async function getShowsWithPerformances() {
   const supabase = await createClient();
-   const { data, error } = await supabase
+  const { data, error } = await supabase
     .from('shows')
     .select(`
       id,
       title,
+      slug,
+      image:image_URL,
+      category,
+      author,
       performances!inner (
-        time
+        time,
+        venue
       )
     `);
 
   if (error) {
     console.error('Error fetching shows with performances:', error);
-    return null;
+    return [];
   }
 
-  console.log('Shows and their performance times:', data);
-  return data;
+  return (
+    data?.map(({ performances, ...show }) => {
+      const perf = performances?.[0];
+      if (!perf) return show;
+      const dt = new Date(perf.time);
+      const date = `${dt.getUTCDate().toString().padStart(2, '0')}.${(dt.getUTCMonth() + 1)
+        .toString()
+        .padStart(2, '0')}`;
+      const time = `${dt.getUTCHours().toString().padStart(2, '0')}:${dt.getUTCMinutes()
+        .toString()
+        .padStart(2, '0')}`;
+      return { ...show, date, time, venue: perf.venue };
+    }) ?? []
+  );
 }
 
 
 
 export default async function ProgramPage() {
-
-  let dataShows = await getShowsWithPerformances();
-
-  return (
-    <MonthlyProgramGuide shows={dataShows} />
-  )
-
+  const dataShows = await getShowsWithPerformances();
+  return <MonthlyProgramGuide shows={dataShows} />
 }


### PR DESCRIPTION
## Summary
- retrieve shows with additional fields and performance details, including image aliasing
- map first performance timestamp into date and time strings and include venue
- pass transformed show data to `MonthlyProgramGuide`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5cb1bf6fc832ba924ff5b315cefe9