### PR TITLE
Use performance data for program listings

### DIFF
--- a/src/app/program/page.jsx
+++ b/src/app/program/page.jsx
@@ -9,8 +9,14 @@ async function getShowsWithPerformances() {
     .select(`
       id,
       title,
+      author,
+      slug,
+      image_URL,
+      poster_URL,
+      category,
       performances!inner (
-        time
+        time,
+        venues(name)
       )
     `);
 


### PR DESCRIPTION
## Summary
- Parse performance timestamps directly instead of custom DD.MM parsing
- Display poster or image URL fields from new query response
- Pull show time and venue from joined performances data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5cb1d2dc8832bae926a73887cdfef