### PR TITLE
Handle file upload errors in admin

### DIFF
--- a/src/app/admin/page.jsx
+++ b/src/app/admin/page.jsx
@@ -170,12 +170,14 @@ function ShowsSection({ supabase }) {
     const { error } = await supabase.storage
       .from('pictures')
       .upload(filePath, file)
-    if (!error) {
-      const { data } = supabase.storage
-        .from('pictures')
-        .getPublicUrl(filePath)
-      setForm({ ...form, [key]: data.publicUrl })
+    if (error) {
+      setStatus({ type: 'error', message: error.message })
+      return
     }
+    const { data } = supabase.storage
+      .from('pictures')
+      .getPublicUrl(filePath)
+    setForm({ ...form, [key]: data.publicUrl })
   }
 
   return (
@@ -442,12 +444,14 @@ function EmployeesSection({ supabase }) {
     const { error } = await supabase.storage
       .from('pictures')
       .upload(filePath, file)
-    if (!error) {
-      const { data } = supabase.storage
-        .from('pictures')
-        .getPublicUrl(filePath)
-      setForm({ ...form, profile_picture_URL: data.publicUrl })
+    if (error) {
+      setStatus({ type: 'error', message: error.message })
+      return
     }
+    const { data } = supabase.storage
+      .from('pictures')
+      .getPublicUrl(filePath)
+    setForm({ ...form, profile_picture_URL: data.publicUrl })
   }
 
   return (


### PR DESCRIPTION
## Summary
- Surface Supabase storage upload errors in show and employee file pickers via setStatus

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6a8b6f948832b8c32e0377c284d1a