### PR TITLE
Use service role to manage employees

### DIFF
--- a/src/app/api/admin/employees/route.js
+++ b/src/app/api/admin/employees/route.js
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server'
+import { createAdminClient } from '../../../../../lib/supabase/admin'
+
+export async function POST(request) {
+  const body = await request.json()
+  const supabase = createAdminClient()
+  const { data, error } = await supabase.from('employees').insert([body])
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+export async function PUT(request) {
+  const { id, ...updates } = await request.json()
+  if (!id) {
+    return NextResponse.json({ error: 'ID is required' }, { status: 400 })
+  }
+  const supabase = createAdminClient()
+  const { data, error } = await supabase
+    .from('employees')
+    .update(updates)
+    .eq('id', id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+export async function DELETE(request) {
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (!id) {
+    return NextResponse.json({ error: 'ID is required' }, { status: 400 })
+  }
+  const supabase = createAdminClient()
+  const { error } = await supabase.from('employees').delete().eq('id', id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 })
+  }
+  return NextResponse.json({ success: true }, { status: 200 })
+}


### PR DESCRIPTION
## Summary
- add service role backed API to mutate `employees`
- upload employee images on submit and show local previews
- switch admin panel to use new API for create/update/delete

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6ab4f5eb8832b9dcf1f8566cd10d7