### PR TITLE
Auto-sync shows from Entase when admin loads the tab

### DIFF
--- a/src/app/admin/page.jsx
+++ b/src/app/admin/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { createClient } from '../../../lib/supabase/client'
 import StatusMessage from '../../components/ui/status-message'
 import AdminsSection from './admins-section'
@@ -18,14 +18,6 @@ const inputClass =
 const buttonBaseClass = 'text-theater-dark px-4 py-2 rounded self-end'
 const selectClass =
   `${inputClass} cursor-pointer focus:ring-2 focus:ring-theater-accent`
-
-function generateSlug(text) {
-  return text
-    .toLowerCase()
-    .trim()
-    .replace(/[^\w\s-]/g, '')
-    .replace(/\s+/g, '-')
-}
 
 export default function AdminPage() {
   const supabase = createClient()
@@ -72,24 +64,14 @@ export default function AdminPage() {
 }
 
 function ShowsSection({ supabase }) {
-  const emptyForm = {
-    title: '',
-    slug: '',
-    category: '',
-    image_URL: '',
-    poster_URL: '',
-    information: '',
-    author: '',
-    picture_personalURL: '',
-  }
   const pageSize = 10
   const [items, setItems] = useState([])
-  const [form, setForm] = useState(emptyForm)
-  const [editingId, setEditingId] = useState(null)
   const [search, setSearch] = useState('')
   const [page, setPage] = useState(0)
   const [count, setCount] = useState(0)
   const [status, setStatus] = useState(null)
+  const [syncing, setSyncing] = useState(false)
+  const hasSyncedRef = useRef(false)
 
   useEffect(() => {
     fetchData()
@@ -108,34 +90,37 @@ function ShowsSection({ supabase }) {
     if (count !== null) setCount(count)
   }
 
-  async function handleSubmit(e) {
-    e.preventDefault()
+  async function handleSync() {
+    if (syncing) return
     setStatus(null)
-    if (!form.title.trim() || !form.slug.trim() || !form.category.trim()) {
-      setStatus({
-        type: 'error',
-        message: 'Title, category and slug are required.',
+    setSyncing(true)
+    try {
+      const response = await fetch('/api/entase/sync', {
+        method: 'POST',
       })
-      return
+      const result = await response.json()
+      if (!response.ok) {
+        throw new Error(result.error || 'Failed to sync with Entase.')
+      }
+      const { showCount = 0, performanceCount = 0 } = result
+      setStatus({
+        type: 'success',
+        message: `Synced ${showCount} shows and ${performanceCount} performances from Entase.`,
+      })
+      setPage(0)
+      await fetchData()
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message })
+    } finally {
+      setSyncing(false)
     }
-    let result
-    if (editingId) {
-      result = await supabase.from('shows').update(form).eq('id', editingId)
-    } else {
-      result = await supabase.from('shows').insert([form])
-    }
-    if (result.error) {
-      setStatus({ type: 'error', message: result.error.message })
-      return
-    }
-    setStatus({
-      type: 'success',
-      message: editingId ? 'Show updated.' : 'Show added.',
-    })
-    setForm(emptyForm)
-    setEditingId(null)
-    fetchData()
   }
+
+  useEffect(() => {
+    if (hasSyncedRef.current) return
+    hasSyncedRef.current = true
+    handleSync()
+  }, [])
 
   async function handleDelete(id) {
     setStatus(null)
@@ -149,41 +134,9 @@ function ShowsSection({ supabase }) {
     }
   }
 
-  function handleEdit(item) {
-    setForm({
-      title: item.title || '',
-      slug: item.slug || '',
-      category: item.category || '',
-      image_URL: item.image_URL || '',
-      poster_URL: item.poster_URL || '',
-      information: item.information || '',
-      author: item.author || '',
-      picture_personalURL: item.picture_personalURL || '',
-    })
-    setEditingId(item.id)
-  }
-
-  async function handleFileChange(e, key, folder) {
-    const file = e.target.files[0]
-    if (!file) return
-    const filePath = `${folder}/${Date.now()}-${file.name}`
-    const { error } = await supabase.storage
-      .from('pictures')
-      .upload(filePath, file)
-    if (error) {
-      setStatus({ type: 'error', message: error.message })
-      return
-    }
-    const { data } = supabase.storage
-      .from('pictures')
-      .getPublicUrl(filePath)
-    setForm({ ...form, [key]: data.publicUrl })
-  }
-
   return (
     <section className="bg-theater-dark p-6 rounded shadow text-white">
-      <h2 className="text-xl font-semibold mb-4">Shows</h2>
-      <div className="mb-4">
+      <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <input
           placeholder="Search shows"
           value={search}
@@ -193,103 +146,16 @@ function ShowsSection({ supabase }) {
           }}
           className={inputClass}
         />
-      </div>
-      <h3 className="text-lg font-medium mb-2">
-        {editingId ? 'Edit Show' : 'Add New Show'}
-      </h3>
-      <form onSubmit={handleSubmit} className="grid gap-4 sm:grid-cols-2 mb-6">
-        <div className="flex flex-col">
-          <label className="text-sm font-medium">Title</label>
-          <input
-            value={form.title}
-            onChange={(e) => {
-              const title = e.target.value
-              setForm({ ...form, title, slug: generateSlug(title) })
-            }}
-            required
-            className={inputClass}
-          />
-        </div>
-        <div className="flex flex-col">
-          <label className="text-sm font-medium">Slug</label>
-          <input value={form.slug} readOnly className={`${inputClass} opacity-50`} />
-        </div>
-        <div className="flex flex-col">
-          <label className="text-sm font-medium">Category</label>
-          <input
-            value={form.category}
-            onChange={(e) => setForm({ ...form, category: e.target.value })}
-            required
-            className={inputClass}
-          />
-        </div>
-        <div className="flex flex-col">
-          <label className="text-sm font-medium">Author</label>
-          <input
-            value={form.author}
-            onChange={(e) => setForm({ ...form, author: e.target.value })}
-            required
-            className={inputClass}
-          />
-        </div>
-        <div className="flex flex-col">
-          <label className="text-sm font-medium">Poster</label>
-          <input
-            type="file"
-            onChange={(e) => handleFileChange(e, 'poster_URL', 'Posters')}
-            className={inputClass}
-          />
-          {form.poster_URL && (
-            <img
-              src={form.poster_URL}
-              alt="poster preview"
-              className="mt-2 h-48 object-cover"
-            />
-          )}
-        </div>
-        <div className="flex flex-col">
-          <label className="text-sm font-medium">Image</label>
-          <input
-            type="file"
-            onChange={(e) => handleFileChange(e, 'image_URL', 'BigPicturePlays')}
-            className={inputClass}
-          />
-          {form.image_URL && (
-            <img
-              src={form.image_URL}
-              alt="image preview"
-              className="mt-2 h-48 object-cover"
-            />
-          )}
-        </div>
-        <div className="flex flex-col sm:col-span-2">
-          <label className="text-sm font-medium">Information</label>
-          <textarea
-            value={form.information}
-            onChange={(e) => setForm({ ...form, information: e.target.value })}
-            className={`${inputClass} h-32`}
-            required
-          />
-        </div>
-        <div className="flex flex-col sm:col-span-2">
-          <label className="text-sm font-medium">Picture personal URL</label>
-          <input
-            value={form.picture_personalURL}
-            onChange={(e) =>
-              setForm({ ...form, picture_personalURL: e.target.value })
-            }
-            className={inputClass}
-          />
-        </div>
         <button
-          type="submit"
+          onClick={handleSync}
+          disabled={syncing}
           className={`${buttonBaseClass} ${
-            editingId ? 'bg-blue-500' : 'bg-green-500'
-          }`}
+            syncing ? 'bg-theater-hover text-white' : 'bg-theater-accent'
+          } disabled:opacity-60`}
         >
-          {editingId ? 'Update' : 'Add'}
+          {syncing ? 'Syncing…' : 'Sync from Entase'}
         </button>
-      </form>
+      </div>
       <StatusMessage status={status} onClear={() => setStatus(null)} />
       <div className="flex justify-end mb-2 space-x-2">
         <button
@@ -331,13 +197,7 @@ function ShowsSection({ supabase }) {
                   .filter(Boolean)
                   .join(', ')}
               </td>
-              <td className="p-2 border-b border-theater-light space-x-2">
-                <button
-                  onClick={() => handleEdit(item)}
-                  className="text-theater-accent hover:text-[#27AAE1] hover:underline"
-                >
-                  Edit
-                </button>
+              <td className="p-2 border-b border-theater-light">
                 <button
                   onClick={() => handleDelete(item.id)}
                   className="text-red-500 hover:text-[#27AAE1] hover:underline"

--- a/src/app/api/entase/sync/route.js
+++ b/src/app/api/entase/sync/route.js
@@ -1,0 +1,246 @@
+import { NextResponse } from 'next/server'
+
+import { createAdminClient } from '../../../../../lib/supabase/admin'
+import { createClient as createServerClient } from '../../../../../lib/supabase/server'
+
+const ENTASE_BASE_URL = 'https://api.entase.com/v2'
+const DEFAULT_POSTER = 'https://via.placeholder.com/600x900/0B1D2A/FFFFFF?text=Poster'
+const DEFAULT_IMAGE = 'https://via.placeholder.com/1280x720/0B1D2A/FFFFFF?text=Show'
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+}
+
+async function fetchCollection(initialPath, apiKey) {
+  const items = []
+  let url = initialPath.startsWith('http')
+    ? initialPath
+    : `${ENTASE_BASE_URL}${initialPath}`
+
+  while (url) {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      cache: 'no-store',
+    })
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(
+        `Entase request failed for ${url} with status ${response.status}: ${body}`
+      )
+    }
+    const payload = await response.json()
+    const data = payload?.resource?.data ?? []
+    items.push(...data)
+    const cursor = payload?.resource?.cursor
+    if (cursor?.hasMore && cursor?.nextURL) {
+      url = cursor.nextURL.startsWith('http')
+        ? cursor.nextURL
+        : `${ENTASE_BASE_URL}${cursor.nextURL}`
+    } else {
+      url = null
+    }
+  }
+
+  return items
+}
+
+function buildSlug(title, productionId) {
+  const base = slugify(title || `production-${productionId}`)
+  return `${base}-${productionId}`
+}
+
+function extractStory(production) {
+  if (!production) return ''
+  const sections = []
+  if (production.story) {
+    sections.push(production.story)
+  }
+  const meta = []
+  if (production.length) {
+    meta.push(`Продължителност: ${production.length}`)
+  }
+  if (production.minAgeRestriction) {
+    meta.push(`Минимална възраст: ${production.minAgeRestriction}+`)
+  }
+  if (meta.length) {
+    sections.push(meta.join(' • '))
+  }
+  return sections.join('\n\n')
+}
+
+function buildShowRecord(production) {
+  return {
+    title: production.title || `Production ${production.id}`,
+    slug: buildSlug(production.title, production.id),
+    category: 'theater',
+    author: production.author || 'Entase',
+    information: extractStory(production),
+    image_URL: production.image_URL || DEFAULT_IMAGE,
+    poster_URL: production.poster_URL || DEFAULT_POSTER,
+    picture_personalURL: production.picture_personalURL || null,
+  }
+}
+
+function normalizeDate(dateStart) {
+  try {
+    return new Date(dateStart).toISOString()
+  } catch (error) {
+    return null
+  }
+}
+
+export async function POST() {
+  const apiKey = process.env.ENTASE_API_KEY
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'ENTASE_API_KEY is not configured on the server.' },
+      { status: 500 }
+    )
+  }
+
+  const supabase = await createServerClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError) {
+    return NextResponse.json({ error: authError.message }, { status: 401 })
+  }
+
+  if (!user || user.app_metadata?.is_admin !== true) {
+    return NextResponse.json(
+      { error: 'You must be an authenticated admin to perform this action.' },
+      { status: 403 }
+    )
+  }
+
+  try {
+    const [productions, events] = await Promise.all([
+      fetchCollection('/productions?limit=100&sort[id]=asc', apiKey),
+      fetchCollection(
+        '/events?limit=100&filter[status][0]=1&filter[status][1]=2&extend[0]=productionTitle',
+        apiKey
+      ),
+    ])
+
+    if (!productions.length) {
+      return NextResponse.json(
+        { error: 'No productions were returned by the Entase API.' },
+        { status: 502 }
+      )
+    }
+
+    const productionsById = new Map()
+    productions.forEach((production) => {
+      productionsById.set(production.id, production)
+    })
+
+    const productionIdsWithEvents = new Set()
+    events.forEach((event) => {
+      if (productionsById.has(event.productionID)) {
+        productionIdsWithEvents.add(event.productionID)
+      }
+    })
+
+    if (!productionIdsWithEvents.size) {
+      return NextResponse.json(
+        {
+          error:
+            'No active events with matching productions were found in the Entase API.',
+        },
+        { status: 502 }
+      )
+    }
+
+    const showsPayload = Array.from(productionIdsWithEvents).map((id) =>
+      buildShowRecord(productionsById.get(id))
+    )
+
+    const adminClient = createAdminClient()
+
+    const { data: upsertedShows, error: upsertError } = await adminClient
+      .from('shows')
+      .upsert(showsPayload, { onConflict: 'slug' })
+      .select('id, slug')
+
+    if (upsertError) {
+      throw upsertError
+    }
+
+    const slugs = showsPayload.map((show) => show.slug)
+    let shows = upsertedShows ?? []
+
+    if (shows.length !== slugs.length) {
+      const { data: fetchedShows, error: fetchShowsError } = await adminClient
+        .from('shows')
+        .select('id, slug')
+        .in('slug', slugs)
+      if (fetchShowsError) {
+        throw fetchShowsError
+      }
+      shows = fetchedShows
+    }
+
+    const slugToId = new Map(shows.map((show) => [show.slug, show.id]))
+
+    const performancesPayload = events
+      .map((event) => {
+        const production = productionsById.get(event.productionID)
+        if (!production) return null
+        const slug = buildSlug(production.title, production.id)
+        const idShow = slugToId.get(slug)
+        if (!idShow) return null
+        const time = normalizeDate(event.dateStart)
+        if (!time) return null
+        const payload = {
+          idShow,
+          time,
+        }
+        if (event.location?.placeName) {
+          payload.venue = event.location.placeName
+        }
+        return payload
+      })
+      .filter(Boolean)
+
+    const showIds = Array.from(new Set(performancesPayload.map((perf) => perf.idShow)))
+
+    if (showIds.length) {
+      const { error: deletePerformancesError } = await adminClient
+        .from('performances')
+        .delete()
+        .in('idShow', showIds)
+      if (deletePerformancesError) {
+        throw deletePerformancesError
+      }
+    }
+
+    if (performancesPayload.length) {
+      const { error: insertPerformancesError } = await adminClient
+        .from('performances')
+        .insert(performancesPayload)
+      if (insertPerformancesError) {
+        throw insertPerformancesError
+      }
+    }
+
+    return NextResponse.json({
+      status: 'ok',
+      showCount: showsPayload.length,
+      performanceCount: performancesPayload.length,
+    })
+  } catch (error) {
+    console.error('Failed to sync with Entase:', error)
+    return NextResponse.json(
+      { error: error.message || 'Failed to sync with Entase.' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- trigger the Entase sync automatically when the admin Shows tab mounts
- guard the sync handler so repeated clicks do not start overlapping requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbda43cd24832bb34c4af5db6d4a6b